### PR TITLE
fix: add Lovelace resource storage fallback for card registration

### DIFF
--- a/custom_components/divera/__init__.py
+++ b/custom_components/divera/__init__.py
@@ -62,12 +62,12 @@ async def _async_register_card(hass: HomeAssistant) -> None:
 
     try:
         from homeassistant.components.frontend import async_register_extra_module_url
-
+    except ImportError:
+        LOGGER.debug("async_register_extra_module_url not available, trying fallback")
+    else:
         async_register_extra_module_url(hass, card_url)
         LOGGER.debug("Registered Lovelace card via async_register_extra_module_url")
         return
-    except ImportError:
-        LOGGER.debug("async_register_extra_module_url not available, trying fallback")
 
     # Fallback: add directly to Lovelace resource storage (storage mode only)
     try:


### PR DESCRIPTION
async_register_extra_module_url may not be available in all HA builds. Add a second fallback that writes directly into the Lovelace resource storage collection so the card auto-registers without any manual step.